### PR TITLE
Added missing mime type "application/x-java-archive".

### DIFF
--- a/server/storage/src/main/java/org/apache/karaf/cave/server/storage/CaveRepositoryImpl.java
+++ b/server/storage/src/main/java/org/apache/karaf/cave/server/storage/CaveRepositoryImpl.java
@@ -410,6 +410,7 @@ public class CaveRepositoryImpl implements CaveRepository {
         try (InputStream is = conn.getInputStream()) {
             String type = conn.getContentType();
             if ("application/java-archive".equals(type)
+                    || "application/x-java-archive".equals(type)
                     || "application/octet-stream".equals(type)
                     || "application/vnd.osgi.bundle".equals(type)) {
                 // I have a jar/binary, potentially a resource
@@ -525,6 +526,7 @@ public class CaveRepositoryImpl implements CaveRepository {
         try (InputStream is = conn.getInputStream()) {
             String type = conn.getContentType();
             if ("application/java-archive".equals(type)
+                    || "application/x-java-archive".equals(type)
                     || "application/octet-stream".equals(type)
                     || "application/vnd.osgi.bundle".equals(type)) {
                 try {


### PR DESCRIPTION
This is actually a valid mime type for a jar file. I do not know why my jars are being served with this type, but they are, so I am not able to populate the repository. Since it is a valid mime type, I think the correct fix is to just add it.