### PR TITLE
[KARAF-5297] Allow cave proxy and populate repository for URLs with authorization

### DIFF
--- a/assembly/src/main/resources/features.xml
+++ b/assembly/src/main/resources/features.xml
@@ -32,6 +32,7 @@
             mvn:org.apache.karaf.cave/apache-karaf-cave/${project.version}/cfg/filesystem
         </configfile>
         <bundle>mvn:org.jsoup/jsoup/${jsoup.version}</bundle>
+        <bundle>mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>
         <bundle>mvn:org.apache.karaf.cave.server/org.apache.karaf.cave.server.api/${project.version}</bundle>
         <bundle>mvn:org.apache.karaf.cave.server/org.apache.karaf.cave.server.storage/${project.version}</bundle>
         <conditional>

--- a/manual/src/main/asciidoc/user-guide/populate-repository.adoc
+++ b/manual/src/main/asciidoc/user-guide/populate-repository.adoc
@@ -64,3 +64,18 @@ a regex option for the filter. For instance, to pick up only joda-time version 2
 ----
 karaf@root()> cave:repository-populate --filter .*joda-time-2.* my-repository http://repo2.maven.org/maven2/joda-time/joda-time
 ----
+
+When the remote repository requires HTTP authorization parameters, those can be specified in a Properties file:
+
+----
+karaf@root()> cave:repository-populate --properties <properties-file-path> my-repository <remote-repository-url>
+----
+
+where, `remote-repository-url` is the link to the external remote repository and `<properties-file-path>` is the path to a .properties file containing the following keys:
+
+----
+# Authorization parameters for remote repository
+cave.storage.http.username=
+cave.storage.http.password=
+----
+

--- a/manual/src/main/asciidoc/user-guide/proxy-repository.adoc
+++ b/manual/src/main/asciidoc/user-guide/proxy-repository.adoc
@@ -39,3 +39,18 @@ The `cave:repository-proxy` command accepts the filter option, as the `cave:repo
 ----
 karaf@root()> cave:repository-proxy --filter .*joda-time-2.* my-repository http://repo2.maven.org/maven2/joda-time/joda-time
 ----
+
+The `cave:repository-proxy` command accepts the properties option, as the `cave:repository-populate` command:
+
+----
+karaf@root()> cave:repository-proxy --properties <properties-file-path> my-repository <remote-repository-url>
+----
+
+where, `remote-repository-url` is the link to the external remote repository and `<properties-file-path>` is the path to the .properties file containing the following keys:
+
+----
+# Authorization parameters for remote repository
+cave.storage.http.username=
+cave.storage.http.password=
+----
+

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <cxf.version>3.1.0</cxf.version>
         <httpclient.version>4.3.4</httpclient.version>
         <jsoup.version>1.7.3</jsoup.version>
+        <commons-codec.version>1.10</commons-codec.version>
         <karaf.version>4.0.0</karaf.version>
         <osgi.version>5.0.0</osgi.version>
         <wagon.version>1.0</wagon.version>
@@ -391,6 +392,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>1.5</version>
                         <executions>
                             <execution>
                                 <id>attach-assemblies</id>

--- a/server/api/src/main/java/org/apache/karaf/cave/server/api/CaveRepository.java
+++ b/server/api/src/main/java/org/apache/karaf/cave/server/api/CaveRepository.java
@@ -17,6 +17,7 @@
 package org.apache.karaf.cave.server.api;
 
 import java.net.URL;
+import java.util.Properties;
 
 /**
  * Cave repository is a storage area where to upload artifacts.
@@ -80,14 +81,14 @@ public interface CaveRepository {
 
     /**
      * Proxy an URL (for instance a Maven repository), eventually filtering some artifacts,
-     * provide a Properties file containing URL authorization parameters and add repository metadata..
+     * provide a Properties object containing URL authorization parameters and add repository metadata..
      *
      * @param url the URL to proxy.
      * @param filter regex filter on the artifacts URL.
-     * @param properties a Properties file containing URL authorization parameters.
+     * @param properties a Properties object containing URL authorization parameters.
      * @throws Exception
      */
-    public void proxy(URL url, String filter, String properties) throws Exception;
+    public void proxy(URL url, String filter, Properties properties) throws Exception;
 
     /**
      * Populate from a remote URL (for instance a Maven repository), and eventually update the repository metadata.
@@ -110,15 +111,15 @@ public interface CaveRepository {
 
     /**
      * Populate from a remote URL (for instance a Maven repository), eventually filtering artifacts,
-     * provide a Properties file containing URL authorization parameters and eventually update the repository metadata.
+     * provide a Properties object containing URL authorization parameters and eventually update the repository metadata.
      *
      * @param url the URL to copy.
      * @param filter regex filter on the artifacts URL.
-     * @param properties a Properties file containing URL authorization parameters.
+     * @param properties a Properties object containing URL authorization parameters.
      * @param update if true the repository metadata is updated, false else.
      * @throws Exception
      */
-    public void populate(URL url, String filter, String properties, boolean update) throws Exception;
+    public void populate(URL url, String filter, Properties properties, boolean update) throws Exception;
 
     /**
      * Return an URL for the resource at the given URI.

--- a/server/api/src/main/java/org/apache/karaf/cave/server/api/CaveRepository.java
+++ b/server/api/src/main/java/org/apache/karaf/cave/server/api/CaveRepository.java
@@ -79,6 +79,17 @@ public interface CaveRepository {
     public void proxy(URL url, String filter) throws Exception;
 
     /**
+     * Proxy an URL (for instance a Maven repository), eventually filtering some artifacts,
+     * provide a Properties file containing URL authorization parameters and add repository metadata..
+     *
+     * @param url the URL to proxy.
+     * @param filter regex filter on the artifacts URL.
+     * @param properties a Properties file containing URL authorization parameters.
+     * @throws Exception
+     */
+    public void proxy(URL url, String filter, String properties) throws Exception;
+
+    /**
      * Populate from a remote URL (for instance a Maven repository), and eventually update the repository metadata.
      *
      * @param url the URL to copy.
@@ -96,6 +107,18 @@ public interface CaveRepository {
      * @throws Exception
      */
     public void populate(URL url, String filter, boolean update) throws Exception;
+
+    /**
+     * Populate from a remote URL (for instance a Maven repository), eventually filtering artifacts,
+     * provide a Properties file containing URL authorization parameters and eventually update the repository metadata.
+     *
+     * @param url the URL to copy.
+     * @param filter regex filter on the artifacts URL.
+     * @param properties a Properties file containing URL authorization parameters.
+     * @param update if true the repository metadata is updated, false else.
+     * @throws Exception
+     */
+    public void populate(URL url, String filter, String properties, boolean update) throws Exception;
 
     /**
      * Return an URL for the resource at the given URI.

--- a/server/command/src/main/java/org/apache/karaf/cave/server/command/RepositoryPopulateCommand.java
+++ b/server/command/src/main/java/org/apache/karaf/cave/server/command/RepositoryPopulateCommand.java
@@ -46,13 +46,16 @@ public class RepositoryPopulateCommand extends CaveRepositoryCommandSupport {
     @Argument(index = 1, name = "url", description = "The source URL to use", required = true, multiValued = false)
     String url = null;
 
+    @Option(name="-prop", aliases = { "--properties" }, description = "Path to Properties file containing URL authorization parameters", required = false, multiValued = false)
+    String properties;
+
     protected Object doExecute() throws Exception {
         if (getCaveRepositoryService().getRepository(name) == null) {
             System.err.println("Cave repository " + name + " doesn't exist");
             return null;
         }
         CaveRepository repository = getCaveRepositoryService().getRepository(name);
-        repository.populate(new URL(url), filter, !noUpdate);
+        repository.populate(new URL(url), filter, properties, !noUpdate);
         if (!noUpdate) {
             getCaveRepositoryService().install(name);
         }

--- a/server/command/src/main/java/org/apache/karaf/cave/server/command/RepositoryPopulateCommand.java
+++ b/server/command/src/main/java/org/apache/karaf/cave/server/command/RepositoryPopulateCommand.java
@@ -18,6 +18,7 @@ package org.apache.karaf.cave.server.command;
 
 import java.net.URL;
 
+import java.util.Properties;
 import org.apache.karaf.cave.server.api.CaveRepository;
 import org.apache.karaf.cave.server.command.completers.RepositoryCompleter;
 import org.apache.karaf.shell.api.action.Argument;
@@ -47,7 +48,7 @@ public class RepositoryPopulateCommand extends CaveRepositoryCommandSupport {
     String url = null;
 
     @Option(name="-prop", aliases = { "--properties" }, description = "Path to Properties file containing URL authorization parameters", required = false, multiValued = false)
-    String properties;
+    Properties properties;
 
     protected Object doExecute() throws Exception {
         if (getCaveRepositoryService().getRepository(name) == null) {
@@ -61,5 +62,4 @@ public class RepositoryPopulateCommand extends CaveRepositoryCommandSupport {
         }
         return null;
     }
-
 }

--- a/server/command/src/main/java/org/apache/karaf/cave/server/command/RepositoryProxyCommand.java
+++ b/server/command/src/main/java/org/apache/karaf/cave/server/command/RepositoryProxyCommand.java
@@ -18,6 +18,7 @@ package org.apache.karaf.cave.server.command;
 
 import java.net.URL;
 
+import java.util.Properties;
 import org.apache.karaf.cave.server.api.CaveRepository;
 import org.apache.karaf.cave.server.command.completers.RepositoryCompleter;
 import org.apache.karaf.shell.api.action.Argument;
@@ -47,7 +48,7 @@ public class RepositoryProxyCommand extends CaveRepositoryCommandSupport {
     String filter;
 
     @Option(name="-prop", aliases = { "--properties" }, description = "Path to Properties file containing URL authorization parameters", required = false, multiValued = false)
-    String properties;
+    Properties properties;
 
     protected Object doExecute() throws Exception {
         if (getCaveRepositoryService().getRepository(name) == null) {

--- a/server/command/src/main/java/org/apache/karaf/cave/server/command/RepositoryProxyCommand.java
+++ b/server/command/src/main/java/org/apache/karaf/cave/server/command/RepositoryProxyCommand.java
@@ -46,13 +46,16 @@ public class RepositoryProxyCommand extends CaveRepositoryCommandSupport {
     @Option(name = "-f", aliases = { "--filter" }, description = "Regex filter on the artifacts URL", required = false, multiValued = false)
     String filter;
 
+    @Option(name="-prop", aliases = { "--properties" }, description = "Path to Properties file containing URL authorization parameters", required = false, multiValued = false)
+    String properties;
+
     protected Object doExecute() throws Exception {
         if (getCaveRepositoryService().getRepository(name) == null) {
             System.err.println("Cave repository " + name + " doesn't exist");
             return null;
         }
         CaveRepository repository = getCaveRepositoryService().getRepository(name);
-        repository.proxy(new URL(url), filter);
+        repository.proxy(new URL(url), filter, properties);
         if (!noUpdate) {
             getCaveRepositoryService().install(name);
         }

--- a/server/management/src/main/java/org/apache/karaf/cave/server/management/CaveRepositoryMBean.java
+++ b/server/management/src/main/java/org/apache/karaf/cave/server/management/CaveRepositoryMBean.java
@@ -26,8 +26,8 @@ public interface CaveRepositoryMBean {
     void destroyRepository(String name) throws Exception;
     void installRepository(String name) throws Exception;
     void uninstallRepository(String name) throws Exception;
-    void populateRepository(String name, String url, boolean generate, String filter) throws Exception;
-    void proxyRepository(String name, String url, boolean generate, String filter) throws Exception;
+    void populateRepository(String name, String url, boolean generate, String filter, String properties) throws Exception;
+    void proxyRepository(String name, String url, boolean generate, String filter, String properties) throws Exception;
     void updateRepository(String name) throws Exception;
     void uploadArtifact(String repository, String artifactUrl, boolean generate) throws Exception;
 

--- a/server/management/src/main/java/org/apache/karaf/cave/server/management/internal/CaveRepositoryMBeanImpl.java
+++ b/server/management/src/main/java/org/apache/karaf/cave/server/management/internal/CaveRepositoryMBeanImpl.java
@@ -14,6 +14,9 @@
 
 package org.apache.karaf.cave.server.management.internal;
 
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
 import org.apache.karaf.cave.server.api.CaveRepository;
 import org.apache.karaf.cave.server.api.CaveRepositoryService;
 import org.apache.karaf.cave.server.management.CaveRepositoryMBean;
@@ -109,7 +112,7 @@ public class CaveRepositoryMBeanImpl extends StandardMBean implements CaveReposi
             throw new IllegalArgumentException("Cave repository " + name + " doesn't exist");
         }
         CaveRepository repository = getCaveRepositoryService().getRepository(name);
-        repository.populate(new URL(url), filter, properties, generate);
+        repository.populate(new URL(url), filter, Utils.loadProperties(properties), generate);
         if (generate) {
             getCaveRepositoryService().install(name);
         }
@@ -120,7 +123,7 @@ public class CaveRepositoryMBeanImpl extends StandardMBean implements CaveReposi
             throw new IllegalArgumentException("Cave repository " + name + " doesn't exist");
         }
         CaveRepository repository = getCaveRepositoryService().getRepository(name);
-        repository.proxy(new URL(url), filter, properties);
+        repository.proxy(new URL(url), filter, Utils.loadProperties(properties));
         if (generate) {
             getCaveRepositoryService().install(name);
         }
@@ -145,4 +148,21 @@ public class CaveRepositoryMBeanImpl extends StandardMBean implements CaveReposi
         }
     }
 
+    static class Utils {
+
+        /**
+         * Returns the <code>Properties</code> object as represented by the
+         * property list (key and element pairs) in the file path
+         * at the given <code<>propertiesFile</code>.
+         *
+         * @param   propertiesFile a Properties file containing key-element pairs.
+         * @return  a <code>Properties</code> object containing the properties read from the given file.
+         * @throws  IOException if an error occurred when reading from the input stream.
+         */
+        public static Properties loadProperties (String propertiesFile) throws IOException {
+            Properties properties = new Properties();
+            properties.load(new FileInputStream(propertiesFile));
+            return properties;
+        }
+    }
 }

--- a/server/management/src/main/java/org/apache/karaf/cave/server/management/internal/CaveRepositoryMBeanImpl.java
+++ b/server/management/src/main/java/org/apache/karaf/cave/server/management/internal/CaveRepositoryMBeanImpl.java
@@ -104,23 +104,23 @@ public class CaveRepositoryMBeanImpl extends StandardMBean implements CaveReposi
         caveRepositoryService.uninstall(name);
     }
 
-    public void populateRepository(String name, String url, boolean generate, String filter) throws Exception {
+    public void populateRepository(String name, String url, boolean generate, String filter, String properties) throws Exception {
         if (getCaveRepositoryService().getRepository(name) == null) {
             throw new IllegalArgumentException("Cave repository " + name + " doesn't exist");
         }
         CaveRepository repository = getCaveRepositoryService().getRepository(name);
-        repository.populate(new URL(url), filter, generate);
+        repository.populate(new URL(url), filter, properties, generate);
         if (generate) {
             getCaveRepositoryService().install(name);
         }
     }
 
-    public void proxyRepository(String name, String url, boolean generate, String filter) throws Exception {
+    public void proxyRepository(String name, String url, boolean generate, String filter, String properties) throws Exception {
         if (getCaveRepositoryService().getRepository(name) == null) {
             throw new IllegalArgumentException("Cave repository " + name + " doesn't exist");
         }
         CaveRepository repository = getCaveRepositoryService().getRepository(name);
-        repository.proxy(new URL(url), filter);
+        repository.proxy(new URL(url), filter, properties);
         if (generate) {
             getCaveRepositoryService().install(name);
         }

--- a/server/storage/pom.xml
+++ b/server/storage/pom.xml
@@ -58,6 +58,16 @@
             <groupId>org.apache.karaf</groupId>
             <artifactId>org.apache.karaf.util</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server/storage/src/main/java/org/apache/karaf/cave/server/storage/CaveRepositoryImpl.java
+++ b/server/storage/src/main/java/org/apache/karaf/cave/server/storage/CaveRepositoryImpl.java
@@ -17,6 +17,7 @@
 package org.apache.karaf.cave.server.storage;
 
 import java.net.URLConnection;
+import java.util.Properties;
 import javax.xml.stream.XMLStreamException;
 import java.io.File;
 import java.io.FilterInputStream;
@@ -251,11 +252,11 @@ public class CaveRepositoryImpl implements CaveRepository {
      *
      * @param url    the URL to proxyFilesystem. the URL to proxyFilesystem.
      * @param filter regex filter. Only artifacts URL matching the filter will be considered.
-     * @param properties a Properties file containing URL authorization parameters
+     * @param properties a Properties object containing URL authorization parameters
      *                   to access URLs that require authorization.
      * @throws Exception
      */
-    public void proxy(URL url, String filter, String properties) throws Exception {
+    public void proxy(URL url, String filter, Properties properties) throws Exception {
         if (url.getProtocol().equals("file")) {
             // filesystem proxyFilesystem (to another folder)
             File proxyFolder = new File(url.toURI());
@@ -420,9 +421,11 @@ public class CaveRepositoryImpl implements CaveRepository {
      *
      * @param url    the HTTP URL to proxy.
      * @param filter regex filter. Only artifacts URL matching the filter will be considered.
+     * @param properties a Properties object containing URL authorization parameters
+     *                   to access URLs that require authorization.
      * @throws Exception in case of proxy failure.
      */
-    private void proxyHttp(String url, String filter, String properties, List<Resource> resources) throws Exception {
+    private void proxyHttp(String url, String filter, Properties properties, List<Resource> resources) throws Exception {
         LOGGER.debug("Proxying HTTP URL {}", url);
 
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
@@ -465,12 +468,12 @@ public class CaveRepositoryImpl implements CaveRepository {
      *
      * @param url    the URL to copy.
      * @param filter regex filter. Only artifacts URL matching the filter will be considered.
-     * @param properties a Properties file containing URL authorization parameters
+     * @param properties a Properties object containing URL authorization parameters
      *                   to access URLs that require authorization.
      * @param update if true the repository metadata is updated, false else.
      * @throws Exception in case of populate failure.
      */
-    public void populate(URL url, String filter, String properties, boolean update) throws Exception {
+    public void populate(URL url, String filter, Properties properties, boolean update) throws Exception {
         if (url.getProtocol().equals("file")) {
             // populate the Cave repository from a filesystem folder
             File populateFolder = new File(url.toURI());
@@ -551,10 +554,12 @@ public class CaveRepositoryImpl implements CaveRepository {
      *
      * @param url    the "source" HTTP URL.
      * @param filter regex filter. Only artifacts URL matching the filter will be considered.
+     * @param properties a Properties object containing URL authorization parameters
+     *                   to access URLs that require authorization.
      * @param update true if the repository metadata should be updated, false else.
      * @throws Exception in case of populate failure.
      */
-    private void populateFromHttp(String url, String filter, String properties,
+    private void populateFromHttp(String url, String filter, Properties properties,
                                   boolean update, List<Resource> resources) throws Exception {
 
         LOGGER.debug("Populating from HTTP URL {}", url);

--- a/server/storage/src/main/java/org/apache/karaf/cave/server/storage/Utils.java
+++ b/server/storage/src/main/java/org/apache/karaf/cave/server/storage/Utils.java
@@ -50,21 +50,6 @@ public class Utils {
     }
 
     /**
-     * Returns the <code>Properties</code> object as represented by the
-     * property list (key and element pairs) in the file path
-     * at the given <code<>propertiesFile</code>.
-     *
-     * @param   propertiesFile a Properties file containing key-element pairs.
-     * @return  a <code>Properties</code> object containing the properties read from the given file.
-     * @throws  IOException if an error occurred when reading from the input stream.
-     */
-    public static Properties loadProperties (String propertiesFile) throws IOException {
-        Properties properties = new Properties();
-        properties.load(new FileInputStream(propertiesFile));
-        return properties;
-    }
-
-    /**
      * An instance of the <code>Authorizer</code> class
      * sets the <code>HttpHeaders.AUTHORIZATION</code> request.
      */
@@ -74,18 +59,17 @@ public class Utils {
         private static final String HTTP_USERNAME = "cave.storage.http.username";
         private static final String HTTP_PASSWORD = "cave.storage.http.password";
 
-        // a Properties object to store the contents of the Properties file.
+        // a Properties object to store the authorization parameters.
         private Properties properties;
 
         /**
          * Instantiates an object of the <code>Authorizer</code> class
-         * with the given <code>propertiesFile</code>.
+         * with the given <code>properties</code>.
          *
-         * @param   propertiesFile a Properties file containing key-element pairs.
-         * @throws  IOException if an error occurred when reading from the input stream.
+         * @param   properties a Properties object containing key-element pairs.
          */
-        public Authorizer (String propertiesFile) throws IOException {
-            this.properties = Utils.loadProperties(propertiesFile);
+        public Authorizer (Properties properties) {
+            this.properties = properties;
         }
 
         /**

--- a/server/storage/src/main/java/org/apache/karaf/cave/server/storage/Utils.java
+++ b/server/storage/src/main/java/org/apache/karaf/cave/server/storage/Utils.java
@@ -16,12 +16,18 @@
  */
 package org.apache.karaf.cave.server.storage;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Properties;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+import org.jsoup.Connection;
 
 public class Utils {
 
@@ -42,4 +48,110 @@ public class Utils {
         }
     }
 
+    /**
+     * Returns the <code>Properties</code> object as represented by the
+     * property list (key and element pairs) in the file path
+     * at the given <code<>propertiesFile</code>.
+     *
+     * @param   propertiesFile a Properties file containing key-element pairs.
+     * @return  a <code>Properties</code> object containing the properties read from the given file.
+     * @throws  IOException if an error occurred when reading from the input stream.
+     */
+    public static Properties loadProperties (String propertiesFile) throws IOException {
+        Properties properties = new Properties();
+        properties.load(new FileInputStream(propertiesFile));
+        return properties;
+    }
+
+    /**
+     * An instance of the <code>Authorizer</code> class
+     * sets the <code>HttpHeaders.AUTHORIZATION</code> request.
+     */
+    public static class Authorizer {
+
+        // Property keys expected in the Properties file.
+        private static final String HTTP_USERNAME = "cave.storage.http.username";
+        private static final String HTTP_PASSWORD = "cave.storage.http.password";
+
+        // a Properties object to store the contents of the Properties file.
+        private Properties properties;
+
+        /**
+         * Instantiates an object of the <code>Authorizer</code> class
+         * with the given <code>propertiesFile</code>.
+         *
+         * @param   propertiesFile a Properties file containing key-element pairs.
+         * @throws  IOException if an error occurred when reading from the input stream.
+         */
+        public Authorizer (String propertiesFile) throws IOException {
+            this.properties = Utils.loadProperties(propertiesFile);
+        }
+
+        /**
+         * Returns the given <code>HttpURLConnection</code> object
+         * modified by setting the <code>HttpHeaders.AUTHORIZATION</code> header
+         * depending on whether or not the authorization keys have been set.
+         *
+         * @param   connection an instance of <code>HttpURLConnection</code>.
+         * @return  a modified <code>HttpURLConnection</code> object.
+         */
+        public HttpURLConnection authorize(HttpURLConnection connection) {
+            if (containsAuthorizationKeys()) {
+                connection.setRequestProperty(HttpHeaders.AUTHORIZATION, getAuthorizationHeader());
+            }
+            return connection;
+        }
+
+        /**
+         * Returns the given <code>Connection</code> object
+         * modified by setting the <code>HttpHeaders.AUTHORIZATION</code> header
+         * depending on whether or not the authorization keys have been set.
+         *
+         * @param   connection an instance of <code>Connection</code>.
+         * @return  a modified <code>Connection</code> object.
+         */
+        public Connection authorize(Connection connection) {
+            if (containsAuthorizationKeys()) {
+                connection.header(HttpHeaders.AUTHORIZATION, getAuthorizationHeader());
+            }
+            return connection;
+        }
+
+        /**
+         * Returns <code>true</code>, iff the <code>Properties</code> file
+         * contains the required Authorization keys.
+         *
+         * @return  <code>true</code> iff the Authorization keys are present.
+         */
+        private boolean containsAuthorizationKeys() {
+            return properties.containsKey(HTTP_USERNAME) && properties.containsKey(HTTP_PASSWORD);
+        }
+
+        /**
+         * Returns the <code>String</code> representation
+         * of the Authorization header.
+         *
+         * @return  the Authorization header.
+         */
+        private String getAuthorizationHeader () {
+            return getAuthorizationHeader(
+                    properties.getProperty(HTTP_USERNAME),
+                    properties.getProperty(HTTP_PASSWORD)
+            );
+        }
+
+        /**
+         * Returns the encoded <code>String</code> representation
+         * of the Authorization header for the given username and password.
+         *
+         * @param   username the username for the <code>HttpHeaders.AUTHORIZATION</code> header.
+         * @param   password the password for the <code>HttpHeaders.AUTHORIZATION</code> header.
+         * @return  an encoded <code>String</code> representation for Authorization.
+         */
+        private String getAuthorizationHeader (String username, String password) {
+            String auth = username + ":" + password;
+            byte[] encodedAuth = Base64.encodeBase64(auth.getBytes());
+            return "Basic " + new String(encodedAuth);
+        }
+    }
 }

--- a/server/storage/src/main/java/org/apache/karaf/cave/server/storage/Utils.java
+++ b/server/storage/src/main/java/org/apache/karaf/cave/server/storage/Utils.java
@@ -19,6 +19,7 @@ package org.apache.karaf.cave.server.storage;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URLConnection;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -96,6 +97,21 @@ public class Utils {
          * @return  a modified <code>HttpURLConnection</code> object.
          */
         public HttpURLConnection authorize(HttpURLConnection connection) {
+            if (containsAuthorizationKeys()) {
+                connection.setRequestProperty(HttpHeaders.AUTHORIZATION, getAuthorizationHeader());
+            }
+            return connection;
+        }
+
+        /**
+         * Returns the given <code>URLConnection</code> object
+         * modified by setting the <code>HttpHeaders.AUTHORIZATION</code> header
+         * depending on whether or not the authorization keys have been set.
+         *
+         * @param   connection an instance of <code>URLConnection</code>.
+         * @return  a modified <code>URLConnection</code> object.
+         */
+        public URLConnection authorize(URLConnection connection) {
             if (containsAuthorizationKeys()) {
                 connection.setRequestProperty(HttpHeaders.AUTHORIZATION, getAuthorizationHeader());
             }


### PR DESCRIPTION
- Allow HTTP Basic Authorization for cave:repository-proxy.
- Allow HTTP Basic Authorization for cave:repository-populate.
- Reads Authorization parameters from a Properties file having keys: 
'cave.storage.http.username' and 'cave.storage.http.password'. 
- JIRA: https://issues.apache.org/jira/browse/KARAF-5297
