### PR TITLE
[KARAF-3827] - Fix Cave rest service doesn't retrieve the repositories

### DIFF
--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -44,6 +44,10 @@
             <artifactId>org.apache.karaf.cave.server.storage</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>org.apache.karaf.util</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
         </dependency>
@@ -61,6 +65,9 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Private-Package>
+                            org.apache.karaf.util
+                        </Private-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/server/rest/pom.xml
+++ b/server/rest/pom.xml
@@ -44,12 +44,12 @@
             <artifactId>org.apache.karaf.cave.server.storage</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.karaf</groupId>
-            <artifactId>org.apache.karaf.util</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.karaf</groupId>
+            <artifactId>org.apache.karaf.util</artifactId>
         </dependency>
     </dependencies>
 

--- a/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Repository.java
+++ b/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Repository.java
@@ -1,36 +1,158 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.apache.karaf.cave.server.rest;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
 
 import org.apache.karaf.cave.server.api.CaveRepository;
+import org.apache.karaf.util.XmlUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 @XmlRootElement(name = "cave-repository")
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlType(name = "Repository", propOrder = {"name", "increment", "location", "resources"})
 public class Repository {
 
-    private final CaveRepository repository;
-
+    @XmlElement(name = "name")
+    private String name;
+    @XmlElement(name = "increment")
+    private long increment;
+    @XmlElement(name = "location")
+    private String location;
+    @XmlElement(name = "resources")
+    private List<Resource> resources;
+    
     public Repository() {
-        repository = null;
+        // require for JABX IllegalAnnotationExceptions
     }
 
     public Repository(CaveRepository repository) {
-        this.repository = repository;
+        this.name = repository.getName();
+        this.increment = repository.getIncrement();
+        this.location = repository.getLocation();
+
+        try {
+            Document doc = XmlUtils.parse(repository.getRepositoryXml().toExternalForm());
+
+            // get all resource elements
+            NodeList resourceList = doc.getElementsByTagName("resource");
+
+            if (resourceList.getLength() > 0) {
+                this.resources = new ArrayList<>();
+            }
+
+            // read resource
+            for (int vI = 0; vI < resourceList.getLength(); vI++) {
+
+                Element nodeResource = (Element) resourceList.item(vI);
+                Resource resource = new Resource();
+
+                NodeList capabilityList = nodeResource.getElementsByTagName("capability");
+
+                // read capability
+                for (int vInt = 0; vInt < capabilityList.getLength(); vInt++) {
+
+                    Element capability = (Element) capabilityList.item(vInt);
+
+                    if (capability.hasAttribute("namespace")) {
+
+                        Element attribute = (Element) capability.getFirstChild();
+
+                        while (attribute != null) {
+
+                            if (capability.getAttribute("namespace").equals("osgi.identity")) {
+
+                                switch (attribute.getAttribute("name")) {
+                                    case "osgi.identity":
+                                        resource.setIdentity(attribute.getAttribute("value"));
+                                        break;
+                                    case "type":
+                                        resource.setType(attribute.getAttribute("value"));
+                                        break;
+                                    case "version":
+                                        resource.setVersion(attribute.getAttribute("value"));
+                                        break;
+                                    default:
+                                        break;
+                                }
+
+                            } else if (capability.getAttribute("namespace")
+                                    .equals("osgi.content")) {
+                                switch (attribute.getAttribute("name")) {
+                                    case "url":
+                                        // name of the artefact, the baseURI of the HttpServlet
+                                        // for download is not available
+                                        resource.setArtefact(attribute.getAttribute("value"));
+                                        break;
+                                    default:
+                                        break;
+                                }
+                            }
+
+                            attribute = (Element) attribute.getNextSibling();
+                        }
+                    }
+                }
+
+                getResources().add(resource);
+            }
+
+        } catch (Exception exception) {
+            // TODO Auto-generated catch block
+        }
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String nameIn) {
+        name = nameIn;
+    }
+
+    public long getIncrement() {
+        return increment;
+    }
+
+    public void setIncrement(long incrementIn) {
+        increment = incrementIn;
+    }
+
+    public List<Resource> getResources() {
+        return resources;
+    }
+
+    public void setResources(List<Resource> resourcesIn) {
+        resources = resourcesIn;
+    }
+    
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String locationIn) {
+        location = locationIn;
     }
 
 }

--- a/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Repository.java
+++ b/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Repository.java
@@ -1,16 +1,18 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.karaf.cave.server.rest;
 
@@ -119,7 +121,7 @@ public class Repository {
             }
 
         } catch (Exception exception) {
-            // TODO Auto-generated catch block
+            // do nothing
         }
     }
 

--- a/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Resource.java
+++ b/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Resource.java
@@ -1,0 +1,55 @@
+package org.apache.karaf.cave.server.rest;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement(name = "resource")
+@XmlAccessorType(XmlAccessType.NONE)
+@XmlType(name = "Resource", propOrder = {"identity", "type", "version", "artefact"})
+public class Resource {
+
+    @XmlElement(name = "identity")
+    private String identity;
+    @XmlElement(name = "type")
+    private String type;
+    @XmlElement(name = "version")
+    private String version;
+    @XmlElement(name = "artefact")
+    private String artefact;
+
+
+    public String getIdentity() {
+        return identity;
+    }
+
+    public void setIdentity(String pIdentity) {
+        identity = pIdentity;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String pType) {
+        type = pType;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String pVersion) {
+        version = pVersion;
+    }
+
+    public String getArtefact() {
+        return artefact;
+    }
+
+    public void setArtefact(String pArtefact) {
+        artefact = pArtefact;
+    }
+}

--- a/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Resource.java
+++ b/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Resource.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.karaf.cave.server.rest;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Service.java
+++ b/server/rest/src/main/java/org/apache/karaf/cave/server/rest/Service.java
@@ -16,12 +16,13 @@
  */
 package org.apache.karaf.cave.server.rest;
 
-import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 
 import org.apache.karaf.cave.server.api.CaveRepository;
 import org.apache.karaf.cave.server.api.CaveRepositoryService;
@@ -47,9 +48,9 @@ public class Service {
      * @throws Exception in case of creation failure.
      */
     @POST
-    @Consumes("application/xml")
-    @Produces("application/xml")
-    public Repository create(String name, boolean scan) throws Exception {
+    @Path("/repositories")
+    @Produces("application/json")
+    public Repository create(@QueryParam(value = "name") String name, @QueryParam(value = "scan") boolean scan) throws Exception {
         return new Repository(service.create(name, scan));
     }
 
@@ -63,9 +64,9 @@ public class Service {
      * @throws Exception in case of creation failure.
      */
     @POST
-    @Consumes("application/xml")
-    @Produces("application/xml")
-    public Repository create(String name, String location, boolean scan) throws Exception {
+    @Path("/repositories")
+    @Produces("application/json")
+    public Repository create(@QueryParam(value = "name") String name, @QueryParam(value = "location") String location, @QueryParam(value = "scan") boolean scan) throws Exception {
         return new Repository(service.create(name, location, scan));
     }
 
@@ -75,7 +76,9 @@ public class Service {
      * @param name the name of the repository.
      * @throws Exception in case of uninstall failure.
      */
-    public void uninstall(String name) throws Exception {
+    @POST
+    @Path("/uninstall")
+    public void uninstall(@QueryParam(value = "name") String name) throws Exception {
         service.uninstall(name);
     }
 
@@ -85,7 +88,9 @@ public class Service {
      * @param name the name of the repository.
      * @throws Exception in case of remove failure.
      */
-    public void remove(String name) throws Exception {
+    @POST
+    @Path("/remove")
+    public void remove(@QueryParam(value = "name") String name) throws Exception {
         service.remove(name);
     }
 
@@ -95,7 +100,9 @@ public class Service {
      * @param name the name of the repository.
      * @throws Exception incase of remove failure.
      */
-    public void destroy(String name) throws Exception {
+    @DELETE
+    @Path("/repositories")
+    public void destroy(@QueryParam(value = "name") String name) throws Exception {
         service.destroy(name);
     }
 
@@ -106,8 +113,8 @@ public class Service {
      * @throws Exception in case of registration failure.
      */
     @POST
-    @Consumes("text/plain")
-    public void install(String name) throws Exception {
+    @Path("/install")
+    public void install(@QueryParam(value = "name") String name) throws Exception {
         service.install(name);
     }
 
@@ -118,13 +125,14 @@ public class Service {
      */
     @GET
     @Path("/repositories")
-    @Produces("application/xml")
+    @Produces("application/json")
     public Repository[] getRepositories() {
         CaveRepository[] repositories = service.getRepositories();
         Repository[] repos = new Repository[repositories.length];
         for (int i = 0; i < repositories.length; i++) {
             repos[i] = new Repository(repositories[i]);
         }
+        
         return repos;
     }
 
@@ -136,7 +144,7 @@ public class Service {
      */
     @GET
     @Path("/repositories/{name}")
-    @Produces("application/xml")
+    @Produces("application/json")
     public Repository getRepository(@PathParam("name") String name) {
         CaveRepository repository = service.getRepository(name);
         if (repository != null) {


### PR DESCRIPTION
Fix the response of **REST** service, add **JSON** response object.

The structure of the object have change : 

- **Repository** object tag with JAXRS annotations, attribute **name**, **location**, **increment** and a list of **Resource**

- **Resource** object tag with JAXRS annotations, attribute **identity**, **type**, **version**, **artefact** link to the XML repository elements.

Add dependency to the **org.apache.karaf.util.XmlUtils** to parse the XML repository.

Add QueryParam JAXRS annotations on the query param method

Change Produces JAXRS annotations **application/xml** to **appplication/json**