### PR TITLE
Updating to a newer Jackson version

### DIFF
--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.9.6</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>${servlet.spec.groupId}</groupId>


### PR DESCRIPTION
Update to the latest Jackson version (due to CVE-2019-14540)